### PR TITLE
Replace Java 8 streams with RxJava to support Android development

### DIFF
--- a/src/main/java/rxfsm/State.java
+++ b/src/main/java/rxfsm/State.java
@@ -17,7 +17,7 @@ public class State {
     private final State initialSubState;
     private final List<Transition> transitions;
 
-    State(String name) {
+    public State(String name) {
         this.name = name;
         this.onEntry = null;
         this.onExit = null;


### PR DESCRIPTION
Android handles fewer Java 8 features. Also, make State public.
